### PR TITLE
Automated Multi Platform Build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,7 +17,7 @@ jobs:
         id: prep
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
-          IMAGE="my.docker.registry/thetonio96/wildfly"
+          IMAGE="thetonio96/wildfly"
           echo ::set-output name=tagged_image::${IMAGE}:${TAG}
           echo ::set-output name=tag::${TAG}
       # This is the a separate action that sets up buildx runner
@@ -72,7 +72,7 @@ jobs:
         id: prep
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
-          IMAGE="my.docker.registry/thetonio96/wildfly"
+          IMAGE="thetonio96/wildfly"
           echo ::set-output name=tagged_image::${IMAGE}:ffmpeg-${TAG}
           echo ::set-output name=tag::${TAG}
       # This is the a separate action that sets up buildx runner

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -36,14 +36,18 @@ jobs:
           key: ${{ runner.os }}-single-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-single-buildx
-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build production image
         uses: docker/build-push-action@v2
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile
-          push: false # This would be set to true in a real world deployment scenario.
+          push: true
           tags: ${{ steps.prep.outputs.tagged_image }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
@@ -87,14 +91,18 @@ jobs:
           key: ${{ runner.os }}-single-buildx-ffmpeg-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-single-buildx-ffmpeg
-
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build production image
         uses: docker/build-push-action@v2
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           file: ./Dockerfile-ffmpeg
-          push: false # This would be set to true in a real world deployment scenario.
+          push: true
           tags: ${{ steps.prep.outputs.tagged_image }}
           cache-from: type=local,src=/tmp/.buildx-ffmpeg-cache
           cache-to: type=local,dest=/tmp/.buildx-ffmpeg-cache-new

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,24 @@
+name: cicd
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          install: true
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+      - name: Build
+        run: |
+          docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t thetonio96/wildfly:ffmpeg-23.0.2-11.0.3 --push -f Dockerfile-ffmpeg .

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 jobs:
-  buildx:
+  build:
     runs-on: ubuntu-latest
     steps:
       # Check out code
@@ -56,3 +56,54 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  build-ffmpeg:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out code
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=$(echo $GITHUB_SHA | head -c7)
+          IMAGE="my.docker.registry/thetonio96/wildfly"
+          echo ::set-output name=tagged_image::${IMAGE}:ffmpeg-${TAG}
+          echo ::set-output name=tag::${TAG}
+      # This is the a separate action that sets up buildx runner
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1.6.0
+        with:
+          install: true
+
+      # Registry login step intentionally missing
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-ffmpeg-cache
+          key: ${{ runner.os }}-single-buildx-ffmpeg-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx-ffmpeg
+
+      - name: Build production image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile-ffmpeg
+          push: false # This would be set to true in a real world deployment scenario.
+          tags: ${{ steps.prep.outputs.tagged_image }}
+          cache-from: type=local,src=/tmp/.buildx-ffmpeg-cache
+          cache-to: type=local,dest=/tmp/.buildx-ffmpeg-cache-new
+        # This ugly bit is necessary if you don't want your cache to grow forever
+        # till it hits GitHub's limit of 5GB.
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-ffmpeg-cache
+          mv /tmp/.buildx-ffmpeg-cache-new /tmp/.buildx-ffmpeg-cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          TAG=$(echo $GITHUB_SHA | head -c7)
+          TAG=${GITHUB_REF#refs/*/}
           IMAGE="thetonio96/wildfly"
           echo ::set-output name=tagged_image::${IMAGE}:${TAG}
           echo ::set-output name=tag::${TAG}
@@ -80,7 +80,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          TAG=$(echo $GITHUB_SHA | head -c7)
+          TAG=${GITHUB_REF#refs/*/}
           IMAGE="thetonio96/wildfly"
           echo ::set-output name=tagged_image::${IMAGE}:ffmpeg-${TAG}
           echo ::set-output name=tag::${TAG}
@@ -133,3 +133,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-ffmpeg-cache
           mv /tmp/.buildx-ffmpeg-cache-new /tmp/.buildx-ffmpeg-cache
+
+# Document was created using the following as an example:
+# https://evilmartians.com/chronicles/build-images-on-github-actions-with-docker-layer-caching

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,9 +26,6 @@ jobs:
         uses: docker/setup-buildx-action@v1.6.0
         with:
           install: true
-
-      # Registry login step intentionally missing
-
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -51,6 +48,7 @@ jobs:
           tags: ${{ steps.prep.outputs.tagged_image }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         # This ugly bit is necessary if you don't want your cache to grow forever
         # till it hits GitHub's limit of 5GB.
         # Temp fix
@@ -81,9 +79,6 @@ jobs:
         uses: docker/setup-buildx-action@v1.6.0
         with:
           install: true
-
-      # Registry login step intentionally missing
-
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:
@@ -106,6 +101,7 @@ jobs:
           tags: ${{ steps.prep.outputs.tagged_image }}
           cache-from: type=local,src=/tmp/.buildx-ffmpeg-cache
           cache-to: type=local,dest=/tmp/.buildx-ffmpeg-cache-new
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
         # This ugly bit is necessary if you don't want your cache to grow forever
         # till it hits GitHub's limit of 5GB.
         # Temp fix

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,8 +1,8 @@
 name: cicd
 
 on:
-  push:
-    branches: [master]
+  release:
+    types: [published]
 
 jobs:
   build:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -54,6 +54,17 @@ jobs:
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ steps.prep.outputs.tagged_image }}"
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: "trivy-results.sarif"
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache
@@ -107,6 +118,17 @@ jobs:
         # Temp fix
         # https://github.com/docker/build-push-action/issues/252
         # https://github.com/moby/buildkit/issues/1896
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: "${{ steps.prep.outputs.tagged_image }}"
+          format: "template"
+          template: "@/contrib/sarif.tpl"
+          output: "trivy-results.sarif"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: "trivy-results.sarif"
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-ffmpeg-cache

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -8,17 +8,51 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     steps:
+      # Check out code
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=$(echo $GITHUB_SHA | head -c7)
+          IMAGE="my.docker.registry/thetonio96/wildfly"
+          echo ::set-output name=tagged_image::${IMAGE}:${TAG}
+          echo ::set-output name=tag::${TAG}
+      # This is the a separate action that sets up buildx runner
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1.6.0
         with:
           install: true
-      - name: Available platforms
-        run: echo ${{ steps.buildx.outputs.platforms }}
-      - name: Build
+
+      # Registry login step intentionally missing
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-single-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-single-buildx
+
+      - name: Build production image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          file: ./Dockerfile
+          push: false # This would be set to true in a real world deployment scenario.
+          tags: ${{ steps.prep.outputs.tagged_image }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+        # This ugly bit is necessary if you don't want your cache to grow forever
+        # till it hits GitHub's limit of 5GB.
+        # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
         run: |
-          docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t thetonio96/wildfly:ffmpeg-23.0.2-11.0.3 --push -f Dockerfile-ffmpeg .
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,47 @@
-FROM adoptopenjdk:11.0.11_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 
 # explicitly set user/group IDs
 RUN groupadd -r wildfly --gid=1023 && useradd -r -g wildfly --uid=1023 -d /opt/wildfly wildfly
 
+RUN apt-get update \
+    && apt-get install -y gnupg netcat-openbsd unzip \
+    && rm -rf /var/lib/apt/lists/*
+
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.13
-RUN arch="$(dpkg --print-architecture)" \
-    && set -x \
-    && apt-get update \
-    && apt-get install -y gnupg netcat-openbsd unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch" \
-    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version \
-    && gosu nobody true
+RUN set -eux; \
+    # save list of currently installed packages for later so we can clean up
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates wget; \
+    if ! command -v gpg; then \
+    apt-get install -y --no-install-recommends gnupg2 dirmngr; \
+    elif gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+    # "This package provides support for HKPS keyservers." (GnuPG 1.x only)
+    apt-get install -y --no-install-recommends gnupg-curl; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+    # verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    command -v gpgconf && gpgconf --kill all || :; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+    # clean up fetch dependencies
+    apt-mark auto '.*' > /dev/null; \
+    [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    \
+    chmod +x /usr/local/bin/gosu; \
+    # verify that the binary works
+    gosu --version; \
+    gosu nobody true
 
 ENV WILDFLY_VERSION=24.0.1.Final \
     KEYCLOAK_VERSION=15.0.2 \

--- a/Dockerfile-ffmpeg
+++ b/Dockerfile-ffmpeg
@@ -1,25 +1,47 @@
-FROM adoptopenjdk:11.0.11_9-jdk-hotspot-focal
+FROM eclipse-temurin:11.0.13_8-jdk-focal
 
 # explicitly set user/group IDs
 RUN groupadd -r wildfly --gid=1023 && useradd -r -g wildfly --uid=1023 -d /opt/wildfly wildfly
 
+RUN apt-get update \
+    && apt-get install -y gnupg netcat-openbsd unzip ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.13
-RUN arch="$(dpkg --print-architecture)" \
-    && set -x \
-    && apt-get update \
-    && apt-get install -y gnupg netcat-openbsd unzip ffmpeg \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -o /usr/local/bin/gosu -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch" \
-    && curl -o /usr/local/bin/gosu.asc -fSL "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$arch.asc" \
-    && export GNUPGHOME="$(mktemp -d)" \
-    && gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-    && gpgconf --kill all \
-    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
-    && chmod +x /usr/local/bin/gosu \
-    && gosu --version \
-    && gosu nobody true
+RUN set -eux; \
+    # save list of currently installed packages for later so we can clean up
+    savedAptMark="$(apt-mark showmanual)"; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates wget; \
+    if ! command -v gpg; then \
+    apt-get install -y --no-install-recommends gnupg2 dirmngr; \
+    elif gpg --version | grep -q '^gpg (GnuPG) 1\.'; then \
+    # "This package provides support for HKPS keyservers." (GnuPG 1.x only)
+    apt-get install -y --no-install-recommends gnupg-curl; \
+    fi; \
+    rm -rf /var/lib/apt/lists/*; \
+    \
+    dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+    wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+    wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+    \
+    # verify the signature
+    export GNUPGHOME="$(mktemp -d)"; \
+    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+    gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+    command -v gpgconf && gpgconf --kill all || :; \
+    rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+    \
+    # clean up fetch dependencies
+    apt-mark auto '.*' > /dev/null; \
+    [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    \
+    chmod +x /usr/local/bin/gosu; \
+    # verify that the binary works
+    gosu --version; \
+    gosu nobody true
 
 ENV WILDFLY_VERSION=24.0.1.Final \
     KEYCLOAK_VERSION=15.0.2 \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# WildFly
+
+## Development
+
+### Requirments
+- [Docker](https://docs.docker.com/get-docker/)
+- [buildx](https://docs.docker.com/buildx/working-with-buildx/)
+
+### Building
+
+Without ffmpeg
+```bash
+docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t thetonio96/wildfly:my-tag --push -f Dockerfile .
+```
+
+With ffmpeg
+```bash
+docker build --platform linux/amd64,linux/arm64,linux/arm/v7 -t thetonio96/wildfly:ffmpeg-my-tag --push -f Dockerfile-ffmpeg .
+```


### PR DESCRIPTION
I would like to propose the following PR to enable a better way to build and publish the docker images to Docker Hub. This PR also adds other steps that are necessary to make this image multi-platform and others are to permit user to contribute the project easily. 

## What has changed:

- Add Github Action Workflow to build on multiple platforms
- Add simple README
- Add dependabot updater for github actions dependencies
- Add Trivy step to look for vulnerabilities of the docker image
- Change GOSU to use documentation example
- Change adoptopenjdk to eclipse-temurin

## What reviewers should know:

Please note that to be able to publish automatically to dockerhub, you must add the following secrets to the Github repo:
```
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
```

To build locally install and use [buildx](https://docs.docker.com/buildx/working-with-buildx/) to be able to build for ARM or other platforms.